### PR TITLE
Adds user namespace endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-twitch-client
 
+[![codecov](https://codecov.io/gh/aidenwallis/go-twitch-client/branch/main/graph/badge.svg?token=s6fH5g5GG0)](https://codecov.io/gh/aidenwallis/go-twitch-client)
+
 A simple, low level wrapper for the [Twitch API](https://dev.twitch.tv). The package deliberately does not make considerations around rate-limiting, token management, or other abstracted behaviour. It aims to be a very simple, thin layer between you and the Twitch API.
 
 For that reason, you should use this package behind any rate-limiting logic, or authorization logic you build into your apps.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-twitch-client
 
-[![codecov](https://codecov.io/gh/aidenwallis/go-twitch-client/branch/main/graph/badge.svg?token=s6fH5g5GG0)](https://codecov.io/gh/aidenwallis/go-twitch-client)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aidenwallis/go-twitch-client.svg)](https://pkg.go.dev/github.com/aidenwallis/go-twitch-client) [![codecov](https://codecov.io/gh/aidenwallis/go-twitch-client/branch/main/graph/badge.svg?token=s6fH5g5GG0)](https://codecov.io/gh/aidenwallis/go-twitch-client)
 
 A simple, low level wrapper for the [Twitch API](https://dev.twitch.tv). The package deliberately does not make considerations around rate-limiting, token management, or other abstracted behaviour. It aims to be a very simple, thin layer between you and the Twitch API.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/aidenwallis/go-twitch-client
 
-go 1.19
+go 1.18

--- a/helix/README.md
+++ b/helix/README.md
@@ -1,0 +1,13 @@
+# Endpoint Progress
+
+## Users
+
+- [x] [Get Users](https://dev.twitch.tv/docs/api/reference#get-users)
+- [x] [Get Users Follows](https://dev.twitch.tv/docs/api/reference#get-users-follows)
+- [x] [Get User Block List](https://dev.twitch.tv/docs/api/reference#get-user-block-list)
+- [x] [Update User](https://dev.twitch.tv/docs/api/reference#update-user)
+- [x] [Block User](https://dev.twitch.tv/docs/api/reference#block-user)
+- [x] [Unblock User](https://dev.twitch.tv/docs/api/reference#unblock-user)
+- [x] [Get User Extensions](https://dev.twitch.tv/docs/api/reference#get-user-extensions)
+- [x] [Get User Active Extensions](https://dev.twitch.tv/docs/api/reference#get-user-active-extensions)
+- [x] [Update User Extensions](https://dev.twitch.tv/docs/api/reference#update-user-extensions)

--- a/helix/client.go
+++ b/helix/client.go
@@ -28,6 +28,7 @@ type helixClient struct {
 
 // RequestOptions are the common options passed to every request
 type RequestOptions struct {
+	// Token is the OAuth bearer token for the Twitch request
 	Token string
 }
 

--- a/helix/users_test.go
+++ b/helix/users_test.go
@@ -164,3 +164,165 @@ func TestUnblockUser(t *testing.T) {
 
 	assert.NoError(t, c.UnblockUser(ctx, in))
 }
+
+func TestUpdateUser(t *testing.T) {
+	ctx := context.Background()
+	in := &UpdateUserRequest{
+		RequestOptions: requestOptions(),
+		Description:    "description",
+	}
+
+	testUser := func(id string) *User {
+		return &User{
+			ID:              id,
+			Login:           "id" + id,
+			DisplayName:     "id" + id,
+			Type:            "",
+			BroadcasterType: "partner",
+			Description:     "description",
+			ProfileImageURL: "https://twitch.tv",
+			OfflineImageURL: "https://twitch.tv",
+			Email:           "",
+			CreatedAt:       time.Now().UTC(),
+		}
+	}
+
+	c := testClient(func(req *http.Request) *testutils.Response {
+		assertToken(t, req)
+		assert.Equal(t, http.MethodPut, req.Method)
+		assert.Equal(t, usersPath+"?description="+in.Description, req.URL.String())
+		return testutils.JSONResponse(t, http.StatusOK, &GetUsersResponse{
+			Data: []*User{
+				testUser("1"),
+			},
+		})
+	})
+
+	resp, err := c.UpdateUser(ctx, in)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Data))
+}
+
+func TestGetUserExtensions(t *testing.T) {
+	ctx := context.Background()
+	in := &GetUserExtensionsRequest{
+		RequestOptions: requestOptions(),
+	}
+
+	testExtension := func(id string) *UserExtension {
+		return &UserExtension{
+			ID:          id,
+			Version:     "0.0.11",
+			Name:        "name",
+			CanActivate: true,
+			Type:        []string{"panel"},
+		}
+	}
+
+	c := testClient(func(req *http.Request) *testutils.Response {
+		assertToken(t, req)
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, userExtensionsListPath, req.URL.String())
+		return testutils.JSONResponse(t, http.StatusOK, &GetUserExtensionsResponse{
+			Data: []*UserExtension{
+				testExtension("1"),
+				testExtension("2"),
+			},
+		})
+	})
+
+	resp, err := c.GetUserExtensions(ctx, in)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(resp.Data))
+}
+
+func TestGetUserActiveExtensions(t *testing.T) {
+	ctx := context.Background()
+	in := &GetUserActiveExtensionsRequest{
+		RequestOptions: requestOptions(),
+		UserID:         "userID",
+	}
+
+	testExtension := func(id string) *UserActiveExtension {
+		return &UserActiveExtension{
+			Active:  true,
+			ID:      id,
+			Name:    id,
+			Version: "0.0.1",
+		}
+	}
+
+	c := testClient(func(req *http.Request) *testutils.Response {
+		assertToken(t, req)
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, userExtensionsPath+"?user_id="+in.UserID, req.URL.String())
+		return testutils.JSONResponse(t, http.StatusOK, &GetUserActiveExtensionsResponse{
+			Data: UserActiveExtensionsProperties{
+				Component: map[string]*UserActiveExtension{
+					"1": testExtension("1"),
+				},
+				Panel: map[string]*UserActiveExtension{
+					"2": testExtension("2"),
+					"3": testExtension("3"),
+				},
+				Overlay: map[string]*UserActiveExtension{
+					"4": testExtension("4"),
+					"5": testExtension("5"),
+					"6": testExtension("6"),
+				},
+			},
+		})
+	})
+
+	resp, err := c.GetUserActiveExtensions(ctx, in)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Data.Component))
+	assert.Equal(t, 2, len(resp.Data.Panel))
+	assert.Equal(t, 3, len(resp.Data.Overlay))
+}
+
+func TestUpdateUserExtensions(t *testing.T) {
+	ctx := context.Background()
+	testExtension := func(id string) *UserActiveExtension {
+		return &UserActiveExtension{
+			Active:  true,
+			ID:      id,
+			Name:    id,
+			Version: "0.0.1",
+		}
+	}
+
+	data := UserActiveExtensionsProperties{
+		Component: map[string]*UserActiveExtension{
+			"1": testExtension("1"),
+		},
+		Panel: map[string]*UserActiveExtension{
+			"2": testExtension("2"),
+			"3": testExtension("3"),
+		},
+		Overlay: map[string]*UserActiveExtension{
+			"4": testExtension("4"),
+			"5": testExtension("5"),
+			"6": testExtension("6"),
+		},
+	}
+	in := &UpdateUserExtensionsRequest{
+		RequestOptions: requestOptions(),
+		Body:           &data,
+	}
+
+	c := testClient(func(req *http.Request) *testutils.Response {
+		assertToken(t, req)
+		assert.Equal(t, http.MethodPut, req.Method)
+		assert.Equal(t, userExtensionsPath, req.URL.String())
+		return testutils.JSONResponse(t, http.StatusOK, &UpdateUserExtensionsResponse{
+			Data: data,
+		})
+	})
+
+	resp, err := c.UpdateUserExtensions(ctx, in)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Data.Component))
+	assert.Equal(t, 2, len(resp.Data.Panel))
+	assert.Equal(t, 3, len(resp.Data.Overlay))
+}

--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -40,6 +40,7 @@ func (c *Client) Request(conf *RequestConfig) *Request {
 	return &Request{
 		client:         c,
 		headersFactory: conf.Headers,
+		headers:        http.Header{},
 		method:         conf.Method,
 		query:          conf.Query,
 		url:            conf.URL,


### PR DESCRIPTION
**Adds codecov and go.dev doc badges to README**

**Adds user endpoint namespace from Helix.**

- [x] [Get Users](https://dev.twitch.tv/docs/api/reference#get-users)
- [x] [Get Users Follows](https://dev.twitch.tv/docs/api/reference#get-users-follows)
- [x] [Get User Block List](https://dev.twitch.tv/docs/api/reference#get-user-block-list)
- [x] [Update User](https://dev.twitch.tv/docs/api/reference#update-user)
- [x] [Block User](https://dev.twitch.tv/docs/api/reference#block-user)
- [x] [Unblock User](https://dev.twitch.tv/docs/api/reference#unblock-user)
- [x] [Get User Extensions](https://dev.twitch.tv/docs/api/reference#get-user-extensions)
- [x] [Get User Active Extensions](https://dev.twitch.tv/docs/api/reference#get-user-active-extensions)
- [x] [Update User Extensions](https://dev.twitch.tv/docs/api/reference#update-user-extensions)